### PR TITLE
Fix SetTables param check

### DIFF
--- a/src/gwtdata.php
+++ b/src/gwtdata.php
@@ -75,9 +75,10 @@
 		 */
 			public function SetTables($arr)
 			{
-				if(is_array($arr) && !empty($arr) && sizeof($arr) <= 2) {
-					$valid = array("TOP_PAGES","TOP_QUERIES","CRAWL_ERRORS","CONTENT_ERRORS",
+				$valid = array("TOP_PAGES","TOP_QUERIES","CRAWL_ERRORS","CONTENT_ERRORS",
 					  "CONTENT_KEYWORDS","INTERNAL_LINKS","EXTERNAL_LINKS","SOCIAL_ACTIVITY");
+					  
+				if(is_array($arr) && !empty($arr) && count($arr) <= count($valid)) {
 					$this->_tables = array();
 					for($i=0; $i < sizeof($arr); $i++) {
 						if(in_array($arr[$i], $valid)) {


### PR DESCRIPTION
In an older version of the library, a check was added to ensure invalid tables weren't searched - the count was 2.  This is an artifact of the old library, and now we can check against the $valid array instead to achieve a similar result.
