### PR TITLE
Remove the '-php' suffix

### DIFF
--- a/src/gwtdata.php
+++ b/src/gwtdata.php
@@ -152,7 +152,7 @@
 					'Email' => $email,
 					'Passwd' => $pwd,
 					'service' => "sitemaps",
-					'source' => "Google-WMTdownloadscript-0.1-php"
+					'source' => "Google-WMTdownloadscript-0.1"
 				);
 				
 				// Before PHP version 5.2.0 and when the first char of $pass is an @ symbol, 


### PR DESCRIPTION
As reported here https://code.google.com/p/php-webmaster-tools-downloads/issues/detail?id=7

The gwtdata.v2.php script no longer works in the last few weeks and we've traced it back to the '-php' suffix.
(The APP_NAME parameter in the Python version at https://code.google.com/p/webmaster-tools-downloads/source/browse/downloader.py doesn't have this suffix)

If someone in Google is listening, it could be a good idea to also accept 'Google-WMTdownloadscript-0.1-php' for the source parameter as any existing deployments of this script are likely not working now.
